### PR TITLE
Add highscore text if the game was won

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,8 @@
     <!-- End game activity -->
     <string name="endgame_win_title">Excellent</string>
     <string name="endgame_win_text" formatted="false">You flooded the board in %1$d moves</string>
+    <string name="endgame_win_highscore_text" formatted="false">Your personal best is %1$d moves</string>
+    <string name="endgame_new_highscore_text">You\'ve reached a new highscore!</string>
     <string name="endgame_lose_title">Game Over</string>
     <string name="endgame_button">New Game</string>
     <string name="endgame_replay">Replay Board</string>


### PR DESCRIPTION
This adds a highscore text if the game was won. If the game was
won for the first time or a new highscore is reached, it will display a
text congratulating the player. Otherwise it wil display the users
personal best. The highscores are saved separately for every game
mode (combination of number of colors and board size).

When a new highscore is reached: 

![](https://lut.im/B1tAk2qDyk/E9yg9GssPftv0cDm.png)

When the game is won, but it isn't a new highscore:

![](https://lut.im/JJYVuuPsZg/Ia2wErZxdkVZ2gs4.png)

See #13.