### PR TITLE
Save game progress on app stop

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'com.google.code.gson:gson:2.8.2'
 
     testCompile 'junit:junit:4.12'
     testCompile 'com.android.support.test:runner:0.5'

--- a/app/src/main/java/com/gunshippenguin/openflood/Game.java
+++ b/app/src/main/java/com/gunshippenguin/openflood/Game.java
@@ -1,7 +1,6 @@
 package com.gunshippenguin.openflood;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.Random;
@@ -29,8 +28,7 @@ public class Game {
         this.numColors = numColors;
         this.seed = generateRandomSeed();
         initBoard();
-
-        maxSteps = (int) 30 * (boardSize * numColors) / (17 * 6);
+        initMaxSteps();
     }
 
     public Game(int boardSize, int numColors, String seed) {
@@ -39,8 +37,17 @@ public class Game {
         this.numColors = numColors;
         this.seed = seed;
         initBoard();
+        initMaxSteps();
+    }
 
-        maxSteps = (int) 30 * (boardSize * numColors) / (17 * 6);
+    public Game(int[][] board, int boardSize, int numColors, int steps, String seed) {
+        // Restore board
+        this.board = board;
+        this.boardSize = boardSize;
+        this.numColors = numColors;
+        this.steps = steps;
+        this.seed = seed;
+        initMaxSteps();
     }
 
     private String generateRandomSeed() {
@@ -50,6 +57,10 @@ public class Game {
             currSeed += SEED_CHARS.charAt(rand.nextInt(SEED_CHARS.length()));
         }
         return currSeed;
+    }
+
+    public int[][] getBoard() {
+        return board;
     }
 
     public int getColor(int x, int y) {
@@ -81,6 +92,10 @@ public class Game {
             }
         }
         return;
+    }
+
+    private void initMaxSteps() {
+        maxSteps = (int) 30 * (boardSize * numColors) / (17 * 6);
     }
 
     public void flood(int replacementColor) {


### PR DESCRIPTION
Currently, the app will lose game progress when the app is stopped (e.g. by pressing the back button). This change makes it possible to restore an ongoing game by saving state to shared preferences on stop, so that the user can continue where they left of.

This change adds [Gson](https://github.com/google/gson) as a dependency, which increases the app size by 0.07MB. This dependency is necessary for serialization and deserialization of the board.